### PR TITLE
Fixed cleanup pulling more logs than required.

### DIFF
--- a/redbot/cogs/cleanup/cleanup.py
+++ b/redbot/cogs/cleanup/cleanup.py
@@ -60,7 +60,7 @@ class Cleanup:
                 if len(to_delete) - 1 < number and check(message) and\
                         (ctx.message.created_at - message.created_at).days < 14:
                     to_delete.append(message)
-                elif (ctx.message.created_at - message.created_at).days >= 14:
+                elif len(to_delete) == number or (ctx.message.created_at - message.created_at).days >= 14:
                     too_old = True
                     break
                 tmp = message
@@ -109,7 +109,7 @@ class Cleanup:
                 if len(to_delete) - 1 < number and check(message) and\
                         (ctx.message.created_at - message.created_at).days < 14:
                     to_delete.append(message)
-                elif (ctx.message.created_at - message.created_at).days >= 14:
+                elif len(to_delete) == number or (ctx.message.created_at - message.created_at).days >= 14:
                     too_old = True
                     break
                 tmp = message
@@ -192,7 +192,7 @@ class Cleanup:
                 if len(to_delete) - 1 < number and \
                         (ctx.message.created_at - message.created_at).days < 14:
                     to_delete.append(message)
-                elif (ctx.message.created_at - message.created_at).days >= 14:
+                elif len(to_delete) == number or (ctx.message.created_at - message.created_at).days >= 14:
                     done = True
                     break
                 tmp = message
@@ -249,7 +249,7 @@ class Cleanup:
                 if len(to_delete) - 1 < number and check(message) and\
                                 (ctx.message.created_at - message.created_at).days < 14:
                     to_delete.append(message)
-                elif (ctx.message.created_at - message.created_at).days >= 14:
+                elif len(to_delete) == number or (ctx.message.created_at - message.created_at).days >= 14:
                     too_old = True
                     break
                 tmp = message
@@ -322,7 +322,7 @@ class Cleanup:
                 if len(to_delete) < number and check(message) and\
                         (ctx.message.created_at - message.created_at).days < 14:
                     to_delete.append(message)
-                elif (ctx.message.created_at - message.created_at).days >= 14:
+                elif len(to_delete) == number or (ctx.message.created_at - message.created_at).days >= 14:
                     # Found a message that is 14 or more days old, stop here
                     too_old = True
                     break


### PR DESCRIPTION
Added conditional statement to break loop once number of messages to be deleted has been reached.

**Description of problem identified**
Previously, on command [p] cleanup messages, the bot would pull the full one thousand messages (as indicated by limit=1000) even when number to cleanup = 1. This was because _break_ was not reached since it would only be reached when messages were older than or equal to 14 days. As a result, even if the first IF condition was not fulfilled, there was no way to end the loop until 1000 iterations. From my tests, waiting for 1000 messages to be pulled from the Discord servers could take up to 3 seconds. This is, of course, unnecessary if the user only seeks to cleanup a few messages.

**Solution**
Added a conditional statement to break the loop once len(to_delete) == number.

Hope this helps.